### PR TITLE
Use merge sort

### DIFF
--- a/Assets/PixelSorter.compute
+++ b/Assets/PixelSorter.compute
@@ -243,6 +243,43 @@ void CS_RGBtoSortValue(uint3 id : SV_DISPATCHTHREADID) {
 }
 
 groupshared half gs_PixelSortCache[1080];
+groupshared half gs_PixelSortIndices[1080];
+groupshared half gs_PixelSortBuffer[1080];
+
+void merge(uint left, uint mid, uint right) {
+    uint i = left, j = mid, k = 0;
+    
+    while (i < mid && j < right) {
+        if (gs_PixelSortCache[gs_PixelSortIndices[i]] > gs_PixelSortCache[gs_PixelSortIndices[j]]) {
+            gs_PixelSortBuffer[k++] = gs_PixelSortIndices[i++];
+        } else {
+            gs_PixelSortBuffer[k++] = gs_PixelSortIndices[j++];
+        }
+    }
+    
+    while (i < mid) {
+        gs_PixelSortBuffer[k++] = gs_PixelSortIndices[i++];
+    }
+    
+    while (j < right) {
+        gs_PixelSortBuffer[k++] = gs_PixelSortIndices[j++];
+    }
+}
+
+void mergeSort(uint size) {
+    for (uint step = 1; step < size; step *= 2) {
+        for (uint left = 0; left + step < size; left += 2 * step) {
+            uint mid = left + step;
+            uint right = (left + 2 * step < size) ? (left + 2 * step) : size;
+            
+            merge(left, mid, right);
+            
+            for (uint i = 0; i < right - left; ++i) {
+                gs_PixelSortIndices[left + i] = gs_PixelSortBuffer[i];
+            }
+        }
+    }
+}
 
 [numthreads(1, 1, 1)]
 void CS_PixelSort(uint3 id : SV_DISPATCHTHREADID) {
@@ -256,50 +293,16 @@ void CS_PixelSort(uint3 id : SV_DISPATCHTHREADID) {
         for (uint k = 0; k < spanLength; ++k) {
             idx = id.xy + k * direction;
             gs_PixelSortCache[k] = _HSLBuffer[idx];
+            gs_PixelSortIndices[k] = k;
         }
 
-        half minValue = gs_PixelSortCache[0];
-        half maxValue = gs_PixelSortCache[0];
-        uint minIndex = 0;
-        uint maxIndex = 0;
-
-        for (uint i = 0; i < (spanLength / 2) + 1; ++i) {
-            for (uint j = 1; j < spanLength; ++j) {
-                half v = gs_PixelSortCache[j];
-
-                if (v == saturate(v)) {
-                    if (v < minValue) {
-                        minValue = v;
-                        minIndex = j;
-                    }
-
-                    if (maxValue < v) {
-                        maxValue = v;
-                        maxIndex = j;
-                    }
-                }
-            }
-
-            uint2 minIdx = 0;
-            uint2 maxIdx = 0;
-            
-            if (_ReverseSorting) {
-                minIdx = id.xy + i * direction;
-                maxIdx = id.xy + (spanLength - i - 1) * direction;
-            } else {
-                minIdx = id.xy + (spanLength - i - 1) * direction;
-                maxIdx = id.xy + i * direction;
-            }
-
-            uint2 colorMinIdx = id.xy + minIndex * direction;
-            uint2 colorMaxIdx = id.xy + maxIndex * direction;
-
-            _SortedBuffer[minIdx] = _ColorBuffer[colorMinIdx];
-            _SortedBuffer[maxIdx] = _ColorBuffer[colorMaxIdx];
-            gs_PixelSortCache[minIndex] = 2;
-            gs_PixelSortCache[maxIndex] = -2;
-            minValue = 1;
-            maxValue = -1;
+        mergeSort(spanLength);
+        
+        for (uint i = 0; i < spanLength; ++i) {
+            uint2 idxOut = id.xy + i * direction;
+            uint sortedIdx = _ReverseSorting ? spanLength - i - 1 : i;
+            uint2 idxIn = id.xy + gs_PixelSortIndices[sortedIdx] * direction;
+            _SortedBuffer[idxOut] = _ColorBuffer[idxIn];
         }
     }
 }


### PR DESCRIPTION
I just realized there's a much simpler way to get an unconditional performance improvement without changing your shader dispatch architecture.
What even possessed you to use (min-max) selection sort (and call it "insertion sort" in a comment) with its (N^2) complexity? Just it's O(N) write complexity? You should read up on indirect sorting.
Why did you even use min-max selection sort instead of a normal selection sort? You didn't even use the 3/2*N-comparison variant (where you go through the array two elements at a time and compare the lesser of them with the minimum and the greater of them with the maximum) which is what actually makes it better than regular selection sort. Doesn't this have worse cache performance as it jumps back and forth between the front and back of the texture? Just curious, I haven't tested it so it's possible this actually somehow has better cache performance, I'm not particularly a cache optimization master so idk. Oh, is it from before you cached the values into groupshared memory? I guess it does have 2x fewer reads even without the 3/2 optimization, right.
Anyway, there's still a lot of room for improvement, like actual multi-threaded sorting, but this problem is really ugly because of the masking (even if you limit span length you still need enough groupshared memory to cover the entire row/column if you want proper parallelization and that's just not possible at resolutions where the performance begins to matter (one way to get around that would be to use odd-even sort with multiple shader calls but that would get really ugly as each thread would need to keep track of the spans on the borders with its neighbors, and although it's good in theory the worst case it could be comparatively really bad in the best case which is most cases)) so I'm not going to waste any more of my braincells on it and this is probably the last you'll hear from me.

PS: at resolutions higher than 1024x1024, indices and lengths don't fit exactly into the half-precision floating-point data type that you use for span lengths so things get rounded to the nearest multiple of 2 between 1025 and 1079. I realized that I should have made `gs_PixelSortIndices` and `gs_PixelSortBuffer` `uint`s instead of `half`s after committing but whatever I guess.